### PR TITLE
Auto Click Save Fix

### DIFF
--- a/pagescript.js
+++ b/pagescript.js
@@ -28,13 +28,13 @@ var init = function() {
 		applyButton.addEventListener('click', function(e) {
 			slowBeepSeconds = parseInt(slowInput.value) || 0;
 			fastBeepSeconds = parseInt(fastInput.value) || 0;
-			clickBeepSeconds = parseInt(clickInput.value) || 0;
+			autoClickSeconds = parseInt(clickInput.value) || 0;
 			
 			document.dispatchEvent(new CustomEvent("AutoKnight_storageSet", {
 				detail: {
 					"slowBeepSeconds": slowBeepSeconds,
 					"fastBeepSeconds": fastBeepSeconds,
-					"clickBeepSeconds": clickBeepSeconds
+					"autoClickSeconds": autoClickSeconds
 				}
 			}));
 			


### PR DESCRIPTION
The "Auto Click at __" textbox would not save after "Apply Changes" button was clicked due to a rogue variable called, "clickBeepSeconds", supposed to be called "autoClickSeconds".
